### PR TITLE
Presentations tab/HydroShare uploader improvements

### DIFF
--- a/src/components/Contribute/CoursesContribute.js
+++ b/src/components/Contribute/CoursesContribute.js
@@ -24,7 +24,7 @@ export default function CoursesContribute({ description }) {
             </h3>
         </div>
 
-        <HydroShareToolResourceForm typeContribution = 'course' resourceType="CompositeResource" makePublic={true} keywordToAdd = "nwm_portal_module"/>
+        <HydroShareToolResourceForm typeContribution = 'course' resourceType="CompositeResource" keywordToAdd = "nwm_portal_module"/>
           <ActionButtons
             buttons={[
                 { label: "Add your Course", href: "https://docs.ciroh.org/docs/products/Portal", primary: true },

--- a/src/components/Contribute/HydroShareContribute.js
+++ b/src/components/Contribute/HydroShareContribute.js
@@ -26,7 +26,6 @@ export default function HydroShareContribute({ name="Dataset", icon="💾", type
         resourceType="CompositeResource"
         typeContribution={type}
         keywordToAdd={keyword}
-        makePublic={true} 
       />
 
       <hr className={Appstyles.sectionDivider} />

--- a/src/components/Contribute/PresentationsContribute.js
+++ b/src/components/Contribute/PresentationsContribute.js
@@ -28,7 +28,6 @@ export default function PresentationsTabContributeContent() {
           resourceType="CompositeResource"
           typeContribution='presentations'
           keywordToAdd = "nwm_portal_presentation"
-          makePublic={true} 
         />
 
         <hr className={Appstyles.sectionDivider} />

--- a/src/components/HydroShareToolResourceForm/index.js
+++ b/src/components/HydroShareToolResourceForm/index.js
@@ -34,7 +34,7 @@ export default function HydroShareResourceCreator({
   const [abstract, setAbstract]     = useState('');
   const [keywords, setKeywords]     = useState('');
   const [inputUrl, setInputUrl]     = useState('');   // page / landing-page URL
-  const [docsUrl,  setDocsUrl]      = useState('');   // NEW – documentation URL
+  const [docsUrl,  setDocsUrl]      = useState('');   // documentation URL (apps/datasets only)
 
   const [fundingAgencies, setFundingAgencies] = useState([]);
   const [coverages,       setCoverages]       = useState([]);
@@ -42,6 +42,7 @@ export default function HydroShareResourceCreator({
   const [files,     setFiles]     = useState([]);     // HydroShare files
   const [iconFile,  setIconFile]  = useState(null);   // icon uploaded to S3
   const [presPath,  setPresPath]  = useState('');     // Path for presentation embed on HydroShare
+  const [visibility, setVisibility] = useState('public'); // HydroShare visibility setting
 
   const [loading,         setLoading]         = useState(false);
   const [error,           setError]           = useState('');
@@ -224,8 +225,9 @@ export default function HydroShareResourceCreator({
         setProgressMessage(`Uploaded file: ${f.name}`);
       }
 
-      /* make public (optional) */
-      if (makePublic) {
+      /* Set access rules */
+      if (visibility === "public" || visibility === "private") {
+        const makePublic = (visibility === "public");
         const pubResp = await fetch(
           `${urlBase}/resource/accessRules/${resourceId}/`,
           {
@@ -234,12 +236,31 @@ export default function HydroShareResourceCreator({
               'Content-Type': 'application/json',
               Authorization:  `Basic ${authString}`,
             },
-            body: JSON.stringify({ public: true }),
+            body: JSON.stringify({ "public": makePublic }),
           },
         );
         if (pubResp.status !== 200)
           throw new Error(`Setting access rules failed (HTTP ${pubResp.status})`);
-        setProgressMessage('Resource made public');
+        setProgressMessage(`Resource made ${visibility}`);
+      }
+      else if (visibility === "discoverable") { // TODO: not yet working
+        setProgressMessage(`Resource made discoverable with private link sharing enabled`);
+        const pubResp = await fetch(
+          `${urlBase}/resource/accessRules/${resourceId}/`,
+          {
+            method:  'PUT',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization:  `Basic ${authString}`,
+            },
+            body: JSON.stringify({"discoverable": true, "sharable": true, "allow_private_sharing": true }),
+          },
+        );
+        if (pubResp.status !== 200)
+          throw new Error(`Setting access rules failed (HTTP ${pubResp.status})`);
+      }
+      else {
+        setProgressMessage(`Invalid visibility setting, skipping...`)
       }
 
       /* final link */
@@ -257,7 +278,7 @@ export default function HydroShareResourceCreator({
               'Content-Type': 'application/json',
               Authorization:  `Basic ${authString}`,
             },
-            body: JSON.stringify({ url: extraMetaObj }),
+            body: JSON.stringify(extraMetaObj),
           },
         );
       }
@@ -383,6 +404,24 @@ export default function HydroShareResourceCreator({
           </label>
         )}
 
+        {/* Visibility settings----------------- */}
+        
+        <label className={styles.label}>
+          Visibility
+          <select
+            className={styles.input}
+            value={visibility}
+            onChange={(e) => setVisibility(e.target.value)}
+          >
+            <option value="public">Public</option>
+            {/*<option value="discoverable">Discoverable</option>*/}
+            <option value="private">Private</option>
+          </select>
+          {(visibility === "private") && (
+            <i>Note: Private resources will not appear on CIROH Portal until they are made public or discoverable.</i>
+          )}
+        </label>
+
         {/* hidden advanced editors ----------------------------------- */}
         <div style={{display: 'none'}}>
           <CoveragesInput       onChange={handleCoveragesChange} />
@@ -411,7 +450,11 @@ export default function HydroShareResourceCreator({
             {!loading && resourceUrl && (
               <>
                 <a
-                  href={`/${typeContribution}s#${resourceUrl.split('/')[4]}`}
+                  href={
+                    (visibility === "private") 
+                    ? resourceUrl
+                    : `/${typeContribution}s#${resourceUrl.split('/')[4]}`
+                  }
                   target="_blank"
                   rel="noopener noreferrer"
                 >

--- a/src/components/HydroShareToolResourceForm/index.js
+++ b/src/components/HydroShareToolResourceForm/index.js
@@ -248,6 +248,7 @@ export default function HydroShareResourceCreator({
 
       /* add self URL as custom scimeta if user didn’t supply a link */
       if (!inputUrl.trim()) {
+        extraMetaObj.url = hsUrl;
         await fetch(
           `${urlBase}/resource/${resourceId}/scimeta/custom/`,
           {
@@ -256,7 +257,7 @@ export default function HydroShareResourceCreator({
               'Content-Type': 'application/json',
               Authorization:  `Basic ${authString}`,
             },
-            body: JSON.stringify({ url: hsUrl }),
+            body: JSON.stringify({ url: extraMetaObj }),
           },
         );
       }

--- a/src/components/HydroShareToolResourceForm/index.js
+++ b/src/components/HydroShareToolResourceForm/index.js
@@ -22,7 +22,6 @@ const getTypeString = (type) => {
 
 export default function HydroShareResourceCreator({
   resourceType      = 'ToolResource',
-  makePublic        = false,
   keywordToAdd      = 'nwm_portal_app',
   typeContribution  = 'app',
 }) {
@@ -244,7 +243,6 @@ export default function HydroShareResourceCreator({
         setProgressMessage(`Resource made ${visibility}`);
       }
       else if (visibility === "discoverable") { // TODO: not yet working
-        setProgressMessage(`Resource made discoverable with private link sharing enabled`);
         const pubResp = await fetch(
           `${urlBase}/resource/accessRules/${resourceId}/`,
           {
@@ -253,11 +251,12 @@ export default function HydroShareResourceCreator({
               'Content-Type': 'application/json',
               Authorization:  `Basic ${authString}`,
             },
-            body: JSON.stringify({"discoverable": true, "sharable": true, "allow_private_sharing": true }),
+            body: JSON.stringify({"discoverable": true, "shareable": true, "allow_private_sharing": true }),
           },
         );
         if (pubResp.status !== 200)
           throw new Error(`Setting access rules failed (HTTP ${pubResp.status})`);
+        setProgressMessage(`Resource made discoverable with private link sharing enabled`);
       }
       else {
         setProgressMessage(`Invalid visibility setting, skipping...`)
@@ -413,8 +412,8 @@ export default function HydroShareResourceCreator({
             value={visibility}
             onChange={(e) => setVisibility(e.target.value)}
           >
-            <option value="public">Public</option>
             {/*<option value="discoverable">Discoverable</option>*/}
+            <option value="public">Public (recommended)</option>
             <option value="private">Private</option>
           </select>
           {(visibility === "private") && (


### PR DESCRIPTION
- Added "Collections" tab to Presentations page. This populates using the "ciroh_portal_pres_collections" keyword, and is used to bundle together related presentations for easy browsing.
- Added "Visibility" dropdown to HydroShare submission form, allowing published resources to be made public, discoverable, or private.
   - "Private" will display a warning indicating that the file won't be visible on Portal until its visibility is changed. 
   - Removed the "makePublic" property of `HydroShareToolResourceForm`, as it went entirely unused.
- Bugfix: Submitting a HydroShare resource with no URL no longer results in all other extra metadata being overwritten.
- Bugfix: The presentations page now prioritizes more recent uploads.