### PR TITLE
Feature Requested: Resources Tab

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -99,7 +99,7 @@ const config = {
           {to: '/develop', label: 'Develop', position: 'right'},
           {
             type: 'custom-docs-mega',
-            label: 'Docs',
+            label: 'Resources',
             position: 'left',
           },
           {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -97,11 +97,10 @@ const config = {
           {to: '/contribute', label: 'Contribute', position: 'right'},
           
           {to: '/develop', label: 'Develop', position: 'right'},
-          // {to: '/hydroshare', label: 'HydroShare', position: 'right'},
           {
-            href: "https://docs.ciroh.org/",
-            label: "Docs",
-            position: "left",
+            type: 'custom-docs-mega',
+            label: 'Docs',
+            position: 'left',
           },
           {
             type: 'dropdown',

--- a/src/data/docsMenu.js
+++ b/src/data/docsMenu.js
@@ -1,0 +1,51 @@
+import {
+  MdCloudQueue,
+  MdStorage,
+  MdShare,
+} from 'react-icons/md';
+
+const DOCS_SITE = 'https://docs.ciroh.org';
+const DOCS_BASE = `${DOCS_SITE}/docs`;
+
+const toHref = path =>
+  path.startsWith('/docs/')
+    ? `${DOCS_SITE}${path}`
+    : `${DOCS_BASE}/${path}`;
+
+
+const services = [
+  {
+    id: 'cloudservices',
+    title: 'Public Cloud',
+    description: 'Managed AWS resources, workflows, and security guidance.',
+    slug: 'services/cloudservices',
+    icon: MdCloudQueue,
+  },
+  {
+    id: 'on-prem',
+    title: 'On-Premises',
+    description: 'Guidance for installing CIROH tooling on HPC or data centers.',
+    slug: 'services/on-prem',
+    icon: MdStorage,
+  },
+  {
+    id: 'external-resources',
+    title: 'External Resources',
+    description: 'Partner docs, references, and related knowledge bases.',
+    slug: 'services/external-resources',
+    icon: MdShare,
+  },
+];
+
+const withLinks = section =>
+  section.map(item => ({
+    ...item,
+    href: item.href ?? toHref(item.slug),
+  }));
+
+const docsMenu = {
+  products: [],
+  services: withLinks(services),
+};
+
+export default docsMenu;

--- a/src/pages/resources/resourcesMenu.js
+++ b/src/pages/resources/resourcesMenu.js
@@ -1,0 +1,70 @@
+import {
+  MdStorage,
+  MdSpeakerNotes,
+  MdNotificationsActive,
+  MdShield
+} from 'react-icons/md';
+
+const DOCS_SITE = 'https://docs.ciroh.org';
+const DOCS_BASE = `${DOCS_SITE}/docs`;
+
+const toHref = path => {
+  if (!path) {
+    return DOCS_SITE;
+  }
+
+  if (path.startsWith('http')) {
+    return path;
+  }
+
+  if (path.startsWith('/')) {
+    return `${DOCS_SITE}${path}`;
+  }
+
+  return `${DOCS_BASE}/${path}`;
+};
+
+const docuhub =[
+  {
+    id: 'docuhub-policies',
+    title: 'Policies',
+    description: 'Data, Code Sharing and Infrastructure Policies',
+    slug: 'policies/intro',
+    icon: MdShield,
+  },
+  {
+    id: 'docuhub-services',
+    title: 'IT Resources',
+    description: 'CIROH CyberInfrastructure: Unleashing Potential in Hydrological Research',
+    slug: 'services/intro',
+    icon: MdStorage,
+  },
+  {
+    id: 'docuhub-news',
+    title: 'News',
+    description: 'Stay connected with the latest developments in NextGen water modeling',
+    slug: '/news',
+    icon: MdSpeakerNotes ,
+  },
+  {
+    id: 'docuhub-blog',
+    title: 'Blog',
+    description: 'Comunity Blog',
+    slug: '/blog',
+    icon: MdNotificationsActive ,
+  },
+]
+
+
+const withLinks = section =>
+  section.map(item => ({
+    ...item,
+    href: item.href ?? toHref(item.slug),
+  }));
+
+const docsMenu = {
+  docs: withLinks(docuhub),
+
+};
+
+export default docsMenu;

--- a/src/theme/NavbarItem/ComponentTypes.js
+++ b/src/theme/NavbarItem/ComponentTypes.js
@@ -1,0 +1,23 @@
+import DefaultNavbarItem from '@theme/NavbarItem/DefaultNavbarItem';
+import DropdownNavbarItem from '@theme/NavbarItem/DropdownNavbarItem';
+import LocaleDropdownNavbarItem from '@theme/NavbarItem/LocaleDropdownNavbarItem';
+import SearchNavbarItem from '@theme/NavbarItem/SearchNavbarItem';
+import HtmlNavbarItem from '@theme/NavbarItem/HtmlNavbarItem';
+import DocNavbarItem from '@theme/NavbarItem/DocNavbarItem';
+import DocSidebarNavbarItem from '@theme/NavbarItem/DocSidebarNavbarItem';
+import DocsVersionNavbarItem from '@theme/NavbarItem/DocsVersionNavbarItem';
+import DocsMegaDropdown from '@site/src/theme/NavbarItem/DocsMegaDropdown';
+
+const ComponentTypes = {
+  default: DefaultNavbarItem,
+  localeDropdown: LocaleDropdownNavbarItem,
+  search: SearchNavbarItem,
+  dropdown: DropdownNavbarItem,
+  html: HtmlNavbarItem,
+  doc: DocNavbarItem,
+  docSidebar: DocSidebarNavbarItem,
+  docsVersion: DocsVersionNavbarItem,
+  'custom-docs-mega': DocsMegaDropdown,
+};
+
+export default ComponentTypes;

--- a/src/theme/NavbarItem/DocsMegaDropdown/index.js
+++ b/src/theme/NavbarItem/DocsMegaDropdown/index.js
@@ -1,0 +1,136 @@
+import React, { useState } from 'react';
+import clsx from 'clsx';
+import Link from '@docusaurus/Link';
+import { MdExpandMore } from 'react-icons/md';
+import docsMenu from '@site/src/data/docsMenu';
+import styles from './styles.module.css';
+
+const DOCS_HOME = 'https://docs.ciroh.org';
+
+const columns = [
+  { title: 'Products', items: docsMenu.products ?? [] },
+  { title: 'Services', items: docsMenu.services ?? [] },
+].filter(column => Array.isArray(column.items) && column.items.length > 0);
+
+function MobileColumn({ title, items = [] }) {
+  if (!items.length) {
+    return null;
+  }
+
+  return (
+    <>
+      <li className="menu__list-item">
+        <div className={styles.mobileHeading}>{title}</div>
+      </li>
+      {items.map(item => (
+        <li key={item.id} className="menu__list-item">
+          <Link className="menu__link" to={item.href}>
+            <span className={styles.mobileLinkLabel}>{item.title}</span>
+          </Link>
+        </li>
+      ))}
+    </>
+  );
+}
+
+export default function DocsMegaDropdown({
+  mobile = false,
+  label,
+  ...props
+}) {
+  const [open, setOpen] = useState(false);
+  const hasColumns = columns.length > 0;
+  const labelText = label ?? 'Docs';
+
+  if (mobile) {
+    if (!hasColumns) {
+      return (
+        <li className="menu__list-item">
+          <Link className="menu__link" to={DOCS_HOME}>
+            <span className={styles.mobileLinkLabel}>{labelText}</span>
+          </Link>
+        </li>
+      );
+    }
+
+    return (
+      <>
+        {columns.map(column => (
+          <MobileColumn key={column.title} {...column} />
+        ))}
+      </>
+    );
+  }
+
+  if (!hasColumns) {
+    return (
+      <Link className={clsx('navbar__item', 'navbar__link')} to={DOCS_HOME}>
+        {labelText}
+      </Link>
+    );
+  }
+
+  return (
+    <div
+      className={clsx('navbar__item', styles.dropdownWrapper)}
+      onMouseEnter={() => setOpen(true)}
+      onMouseLeave={() => setOpen(false)}
+      onBlur={event => {
+        if (!event.currentTarget.contains(event.relatedTarget)) {
+          setOpen(false);
+        }
+      }}
+    >
+      <button
+        type="button"
+        className={clsx('navbar__link', styles.trigger)}
+        onClick={() => setOpen(toggle => !toggle)}
+        aria-haspopup="true"
+        aria-expanded={open}
+      >
+        <span>{labelText}</span>
+        <MdExpandMore
+          className={clsx(styles.chevron, open && styles.chevronOpen)}
+          aria-hidden="true"
+        />
+      </button>
+
+      <div
+        className={clsx(styles.dropdownPanel, open && styles.dropdownPanelOpen)}
+        role="menu"
+        aria-label={`${labelText} menu`}
+      >
+        {columns.map(column => (
+          <div key={column.title} className={styles.column}>
+            <p className={styles.columnTitle}>{column.title}</p>
+            <ul className={styles.linkList}>
+              {column.items.map(item => (
+                <li key={item.id}>
+                  <Link
+                    className={styles.dropdownLink}
+                    to={item.href}
+                    onClick={() => setOpen(false)}
+                  >
+                    {item.icon && (
+                      <div className={styles.linkIconWrapper}>
+                        <item.icon className={styles.linkIcon} aria-hidden="true" />
+                      </div>
+                    )}
+                    <div className={styles.linkCopy}>
+                      <span className={styles.linkLabel}>{item.title}</span>
+                      {item.description && (
+                        <span className={styles.linkDescription}>
+                          {item.description}
+                        </span>
+                      )}
+                    </div>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/theme/NavbarItem/DocsMegaDropdown/index.js
+++ b/src/theme/NavbarItem/DocsMegaDropdown/index.js
@@ -2,21 +2,14 @@ import React, { useState } from 'react';
 import clsx from 'clsx';
 import Link from '@docusaurus/Link';
 import { MdExpandMore } from 'react-icons/md';
-import docsMenu from '@site/src/data/docsMenu';
+import docsMenu from '@site/src/pages/resources/resourcesMenu';
 import styles from './styles.module.css';
 
-const DOCS_HOME = 'https://docs.ciroh.org';
-
 const columns = [
-  { title: 'Products', items: docsMenu.products ?? [] },
-  { title: 'Services', items: docsMenu.services ?? [] },
-].filter(column => Array.isArray(column.items) && column.items.length > 0);
+  { title: 'Docs', items: docsMenu.docs },
+];
 
-function MobileColumn({ title, items = [] }) {
-  if (!items.length) {
-    return null;
-  }
-
+function MobileColumn({ title, items }) {
   return (
     <>
       <li className="menu__list-item">
@@ -39,34 +32,14 @@ export default function DocsMegaDropdown({
   ...props
 }) {
   const [open, setOpen] = useState(false);
-  const hasColumns = columns.length > 0;
-  const labelText = label ?? 'Docs';
 
   if (mobile) {
-    if (!hasColumns) {
-      return (
-        <li className="menu__list-item">
-          <Link className="menu__link" to={DOCS_HOME}>
-            <span className={styles.mobileLinkLabel}>{labelText}</span>
-          </Link>
-        </li>
-      );
-    }
-
     return (
       <>
         {columns.map(column => (
           <MobileColumn key={column.title} {...column} />
         ))}
       </>
-    );
-  }
-
-  if (!hasColumns) {
-    return (
-      <Link className={clsx('navbar__item', 'navbar__link')} to={DOCS_HOME}>
-        {labelText}
-      </Link>
     );
   }
 
@@ -88,7 +61,7 @@ export default function DocsMegaDropdown({
         aria-haspopup="true"
         aria-expanded={open}
       >
-        <span>{labelText}</span>
+        <span>{label}</span>
         <MdExpandMore
           className={clsx(styles.chevron, open && styles.chevronOpen)}
           aria-hidden="true"
@@ -98,7 +71,7 @@ export default function DocsMegaDropdown({
       <div
         className={clsx(styles.dropdownPanel, open && styles.dropdownPanelOpen)}
         role="menu"
-        aria-label={`${labelText} menu`}
+        aria-label={`${label} menu`}
       >
         {columns.map(column => (
           <div key={column.title} className={styles.column}>

--- a/src/theme/NavbarItem/DocsMegaDropdown/styles.module.css
+++ b/src/theme/NavbarItem/DocsMegaDropdown/styles.module.css
@@ -1,0 +1,146 @@
+.dropdownWrapper {
+  position: relative;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: var(--ifm-font-weight-semibold);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  transition: background 0.15s ease;
+  font-size: 0.9rem;
+  color: var(--ifm-navbar-link-color);
+}
+
+.trigger:hover,
+.trigger:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.chevron {
+  transition: transform 0.2s ease;
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.dropdownPanel {
+  position: absolute;
+  top: 100%;
+  left: 50%;
+  transform: translate(-50%, 0);
+  background: var(--ifm-navbar-background-color);
+  border-radius: 22px;
+  padding: 1.5rem 2rem;
+  padding-top: 1.75rem;
+  display: flex;
+  gap: 2rem;
+  min-width: 720px;
+  box-shadow: 0 50px 120px -60px rgba(15, 23, 42, 0.65);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  z-index: 1000;
+  margin-top: 0.5rem;
+}
+
+.dropdownPanelOpen {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translate(-50%, 0);
+}
+
+.column {
+  flex: 1;
+  min-width: 220px;
+}
+
+.column:first-child {
+  flex: 2;
+}
+
+.columnTitle {
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.7rem;
+  color: var(--ifm-color-secondary);
+  margin: 0 0 0.5rem;
+}
+
+.linkList {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.dropdownLink {
+  display: flex;
+  gap: 0.75rem;
+  align-items: flex-start;
+  padding: 0.65rem 0.75rem;
+  border-radius: 14px;
+  color: inherit;
+  text-decoration: none;
+  transition: background 0.15s ease, transform 0.15s ease;
+}
+
+.dropdownLink:hover,
+.dropdownLink:focus-visible {
+  background: var(--ifm-color-emphasis-200);
+  text-decoration: none;
+  transform: translateX(2px);
+}
+
+.linkCopy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.linkIconWrapper {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--ifm-color-emphasis-100);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.linkIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+  color: var(--ifm-color-primary);
+}
+
+.linkLabel {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.linkDescription {
+  font-size: 0.8rem;
+  color: var(--ifm-color-secondary);
+}
+
+.mobileHeading {
+  font-weight: 700;
+  font-size: 0.85rem;
+  margin-top: 0.75rem;
+  text-transform: uppercase;
+  color: var(--ifm-color-secondary);
+}
+
+.mobileLinkLabel {
+  font-weight: 600;
+}

--- a/src/theme/NavbarItem/DocsMegaDropdown/styles.module.css
+++ b/src/theme/NavbarItem/DocsMegaDropdown/styles.module.css
@@ -1,53 +1,34 @@
 .dropdownWrapper {
-  position: relative;
+  composes: dropdownWrapper from '../dropdownShared.module.css';
 }
 
 .trigger {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.25rem;
-  font-weight: var(--ifm-font-weight-semibold);
-  background: transparent;
-  border: none;
-  cursor: pointer;
-  padding: 0.25rem 0.5rem;
-  border-radius: 999px;
-  transition: background 0.15s ease;
-  font-size: 0.9rem;
-  color: var(--ifm-navbar-link-color);
-}
-
-.trigger:hover,
-.trigger:focus-visible {
-  background: rgba(255, 255, 255, 0.08);
+  composes: trigger from '../dropdownShared.module.css';
 }
 
 .chevron {
-  transition: transform 0.2s ease;
+  composes: chevron from '../dropdownShared.module.css';
 }
 
 .chevronOpen {
-  transform: rotate(180deg);
+  composes: chevronOpen from '../dropdownShared.module.css';
 }
 
 .dropdownPanel {
   position: absolute;
   top: 100%;
   left: 50%;
-  transform: translate(-50%, 0);
+  transform: translate(-50%, 10px);
   background: var(--ifm-navbar-background-color);
   border-radius: 22px;
-  padding: 1.5rem 2rem;
-  padding-top: 1.75rem;
-  display: flex;
-  gap: 2rem;
-  min-width: 720px;
+  min-width: 340px;
+  padding: 1rem 1.5rem;
   box-shadow: 0 50px 120px -60px rgba(15, 23, 42, 0.65);
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.2s ease, transform 0.2s ease;
   z-index: 1000;
-  margin-top: 0.5rem;
+
 }
 
 .dropdownPanelOpen {
@@ -107,25 +88,15 @@
 }
 
 .linkIconWrapper {
-  width: 2rem;
-  height: 2rem;
-  border-radius: 50%;
-  background: var(--ifm-color-emphasis-100);
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
+  composes: linkIconWrapper from '../dropdownShared.module.css';
 }
 
 .linkIcon {
-  width: 1.2rem;
-  height: 1.2rem;
-  color: var(--ifm-color-primary);
+  composes: linkIcon from '../dropdownShared.module.css';
 }
 
 .linkLabel {
-  font-weight: 600;
-  font-size: 0.95rem;
+  composes: linkLabel from '../dropdownShared.module.css';
 }
 
 .linkDescription {
@@ -142,5 +113,5 @@
 }
 
 .mobileLinkLabel {
-  font-weight: 600;
+  composes: mobileLinkLabel from '../dropdownShared.module.css';
 }

--- a/src/theme/NavbarItem/dropdownShared.module.css
+++ b/src/theme/NavbarItem/dropdownShared.module.css
@@ -1,0 +1,58 @@
+.dropdownWrapper {
+  position: relative;
+}
+
+.trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: var(--ifm-font-weight-semibold);
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  transition: background 0.15s ease;
+  font-size: 1rem;
+  font-family: var(--ifm-font-family-base);
+  color: var(--ifm-navbar-link-color);
+}
+
+.trigger:hover,
+.trigger:focus-visible {
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.chevron {
+  transition: transform 0.2s ease;
+}
+
+.chevronOpen {
+  transform: rotate(180deg);
+}
+
+.linkIconWrapper {
+  width: 2rem;
+  height: 2rem;
+  border-radius: 50%;
+  background: var(--ifm-color-emphasis-100);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+}
+
+.linkIcon {
+  width: 1.2rem;
+  height: 1.2rem;
+  color: var(--ifm-color-primary);
+}
+
+.linkLabel {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.mobileLinkLabel {
+  font-weight: 600;
+}


### PR DESCRIPTION
This pull request introduces a new "Resources" mega dropdown menu in the navbar, replacing the previous "Docs" link. It adds a custom dropdown component for both desktop and mobile views, with improved styling and organization for resource navigation. Supporting data and utility files were added to provide menu items and links, and shared CSS modules were introduced for consistent styling across dropdown components.

**Navigation and Component Updates:**

* Replaced the old "Docs" navbar link in `docusaurus.config.js` with a new custom dropdown menu labeled "Resources" using the `custom-docs-mega` type.
* Added the `DocsMegaDropdown` React component that renders a multi-column dropdown menu for resources, supporting both desktop and mobile views.
* Registered the new dropdown type in the navbar item component mapping via `ComponentTypes.js`.

**Menu Data and Link Handling:**

* Created `resourcesMenu.js` to define resource menu items, including policies, IT resources, news, and blog, with icons and link generation logic.
* Added `docsMenu.js` to provide service-related menu items and link utilities for use in dropdowns.

**Styling Enhancements:**

* Implemented new CSS modules for dropdown layout and interaction, including styles for the mega dropdown and shared dropdown elements. [[1]](diffhunk://#diff-05941d4e5f2c108864f1a3da412fa5f5b6fd86f262d8515feb841e33b1f21418R1-R117) [[2]](diffhunk://#diff-d8c3f10defbda929a4dda920876768ee2d77b77db1bb67998db752bf7d8318b1R1-R58)